### PR TITLE
server extension: PCIe - AIA requirements

### DIFF
--- a/riscv-platform-spec.adoc
+++ b/riscv-platform-spec.adoc
@@ -88,6 +88,7 @@ The M platform has the following extensions:
 |MSI-X     | Enhanced Message Signaled Interrupts
 |INTx      | PCIe Legacy Interrupts
 |PMA       | Physical Memory Attributes
+|PRT       | PCI Routing Table
 |===
 
 === Specifications
@@ -758,8 +759,25 @@ as described in the RISC-V Privileged Architectures specification.
 
 ====== PCIe Interrupts
 * Platforms shall support both INTx and MSI/MSI-x interrupts.
-* Integration with AIA +
-TBD
+* Following are the requirements for INTx:
+** For each root port in the system, the platform shall map all the INTx
+virtual wires to four distinct sources at the APLIC. Each of these sources
+shall be configured as Level0 as described in Table 4.2 (Encoding of the SM
+(Source Mode) field) of the RISC V AIA specification.
+** Platform firmware shall implement the _PRT as described in section 6.2.13 of
+ACPI Specification to describe the mapping of interrupt pins and the
+corresponding interrupt minor identities at the Hart.
+** If interrupt generation for correctable/fatal/non-fatal error messages is
+enabled via the root error command register of the AER capability and the root
+port does not support MSI/MSI-X capability, then the platform is required to
+generate an INTx interrupt via the APLIC.
+* Following are the requirements for MSI:
+** As per the RISC V AIA specification since the number 0 is not a valid
+interrupt identity, the platform software is required to ensure that MSI data
+value assigned to a PCIe function is never 0. For e.g for a PCIe function which
+requests 16 MSI vectors the minimum MSI data value assigned by the platform
+software can be 0x10 so that the function can use lower 4 bits to assert each
+of the 16 vectors.
 
 ====== PCIe cache coherency
 Memory that is cacheable by harts is not kept coherent by hardware when PCIe


### PR DESCRIPTION
This patch adds requirements for mapping PCIe interrupts to
AIA.

Signed-off-by: Mayuresh Chitale <mchitale@ventanamicro.com>