### PR TITLE
Miscellaneous cleanup across the specification

### DIFF
--- a/riscv-platform-spec.adoc
+++ b/riscv-platform-spec.adoc
@@ -64,12 +64,12 @@ toc::[]
 |PRT       | PCI Routing Table
 |===
 
-== Introduction 
+== Introduction
 The platform specification defines a set of platforms that specify requirements
-for interoperability between software and hardware. The Platform Policy 
-<<spec_riscv_platform_policy> defines the various terms used in this platform specification. The platform 
+for interoperability between software and hardware. The Platform Policy <<spec_riscv_platform_policy>>
+defines the various terms used in this platform specification. The platform
 policy also provides the needed detail regarding the scope, coverage, naming,
-versioning, structure, life cycle and compatibility claims for the platform 
+versioning, structure, life cycle and compatibility claims for the platform
 specification. It is recommended that readers get familiar with the platform
 policy while reading this specification.
 
@@ -79,15 +79,15 @@ and “automotive”.
 
 The platform specification currently defines two platforms:
 
-* *OS-A Platform*: This specifies a rich-OS platform for 
-Linux/FreeBSD/Windows - flavors that run on enterprise and embedded class 
+* *OS-A Platform*: This specifies a rich-OS platform for
+Linux/FreeBSD/Windows - flavors that run on enterprise and embedded class
 application processors. The OS-A platform has a base feature set and extensions
 as shown below: +
 ** *Base*
 ** *Server Extension*
 
-* *M Platform*: This specifies an RTOS platform for bare-metal applications and 
-small operating systems running on a microcontroller. The M platform has a base 
+* *M Platform*: This specifies an RTOS platform for bare-metal applications and
+small operating systems running on a microcontroller. The M platform has a base
 feature set and extensions as shown below: +
 ** *Base*
 ** *Physical Memory Protection (PMP) Extension*
@@ -100,9 +100,9 @@ feature set and extensions as shown below: +
 === Base
 ==== ISA Requirements
 
-===== ISA Profile Requirements 
-* The OS-A platform must comply with the following profiles defined by the 
-RISC-V profiles specification <<spec_profiles>> 
+===== ISA Profile Requirements
+* The OS-A platform must comply with the following profiles defined by the
+RISC-V profiles specification <<spec_profiles>>
 ** RVA22U profile for user-mode.
 ** RVA22S profile for supervisor-mode.
 ** RVM20M64 profile for machine-mode.
@@ -131,13 +131,19 @@ values).
 * All hart PMA regions for main memory must be marked as coherent.
 * Memory accesses by I/O masters can be coherent or non-coherent with respect
 to all hart-related caches.
+[sidebar]
+--
+[underline]*_Recommendation_*
 
+User-mode programs should not execute the `fence.i` instruction.
+
+--
 ===== Machine Mode
 * mvendorid, marchid, mimpid and mhartid registers must be supported and not
 hardwired to 0.
 
 * misa
-** if H extension is supported then the H bit must be writable.
+** If H extension is supported then the H bit must be writable.
 * mstatus
 ** TVM bit must not be hardwired to 0.
 ** TW bit must not be hardwired to 0.
@@ -157,11 +163,11 @@ from M-mode' must be writable.
 ** Bits for MSI, MTI and MEI must be hardwired to 0.
 
 * mcounteren
-** writeable bits must be implemented for all supported (not hardwired to zero)
+** Writeable bits must be implemented for all supported (not hardwired to zero)
 hpmcounters.
 
 * mcountinhibit
-** writeable bits must be implemented for all supported (not hardwired to zero)
+** Writeable bits must be implemented for all supported (not hardwired to zero)
 hpmcounters.
 
 * mtval
@@ -186,7 +192,7 @@ as mstatus.UBE.
 ** The alignment constraint for BASE fields must be at most 256B.
 
 * scounteren
-** writeable bits must be implemented for all supported (not hardwired to zero)
+** Writeable bits must be implemented for all supported (not hardwired to zero)
 hpmcounters.
 
 * stval
@@ -203,7 +209,7 @@ non-zero and zero values as architecturally defined.
 ** VTVM bit must not be hardwired to 0.
 
 * hcounteren
-** writeable bits must be implemented for all supported (not hardwired to zero)
+** Writeable bits must be implemented for all supported (not hardwired to zero)
 hpmcounters.
 
 * htval
@@ -230,20 +236,13 @@ non-zero and zero values as architecturally defined.
 ** For RV32, Bare and Sv32 translation modes must be supported.
 ** For RV64, Bare and Sv39 translation modes must be supported.
 
-[sidebar]
---
-[underline]*_Recommendation_*
-
-User-mode programs should not execute the `fence.i` instruction.
-
---
-==== PMU 
+==== PMU
 
 The RVA22 profile defines 32 PMU counters out-of-which first three counters are
 defined by the privilege specification while other 29 counters are programmable.
-The SBI PMU extension defines a set of hardware events that can be monitored 
-using these programmable counters. This section defines the minimum number of 
-programmable counters and hardware events required for an OS-A compatible 
+The SBI PMU extension defines a set of hardware events that can be monitored
+using these programmable counters. This section defines the minimum number of
+programmable counters and hardware events required for an OS-A compatible
 platform.
 
 * Counters
@@ -281,8 +280,7 @@ both).
 must be at least the number of implemented bits of scontext.
   * Rationale: This allows matching on every possible scontext.
 - If textra.sselect=2 is supported, the number of implemented bits of svalue
-must be at least ASIDLEN.
-  * Rationale: This allows matching on every possible ASID.
+must be at least ASIDLEN to match every possible ASID.
 - In textra, mhselect must support the value 0.  If the H extension is
 supported then mhselect must also support either values 1 and 5 or values 2
 and 6 (or all four).
@@ -309,14 +307,11 @@ above.
  supported modes and support for textra as above.
   * Rationale: The debugger needs watchpoints and 4 is a sufficient baseline.
 - Implement at least one trigger capable of icount and support for textra as
-above.
-  * Rationale: Self-hosted single step needs this
+above for self-hosted single step needs this
 - Implement at least one trigger capable of etrigger and support for textra as
-above.
-  * Rationale: Debuggers need to be able to catch exceptions.
+above to catch exceptions.
 - Implement at least one trigger capable of itrigger and support for textra as
-above.
-  * Rationale: Debuggers need to be able to catch interrupts.
+above to catch interrupts.
 - The minimum trigger requirements must be met for action=0 and for action=1
 (possibly by the same triggers)
   * Rationale: The intent is to have full support for external debug and full
@@ -363,21 +358,21 @@ categories described in following sub-sections.
 
 [#legacy_wired_irqs]
 ====== Legacy wired IRQs - DEPRECATED
-** One or more PLIC devices to support wired interrupts
-** One or more ACLINT MSWI devices to support M-mode software interrupts
-** Software interrupts for S-mode and VS-mode supported using the
+** One or more PLIC devices are required to support wired interrupts
+** One or more ACLINT MSWI devices are required to support M-mode software interrupts
+** Software interrupts for S-mode and VS-mode are supported using the
    SBI IPI extension
-** Compatibile with legacy platforms having PLIC plus CLINT devices
-** MSI external interrupts not supported
+** This category is ompatibile with legacy platforms having PLIC plus CLINT devices
+** MSI external interrupts are not supported
 ** MSI virtualization is not supported
 
 [#only_wired_irqs]
 ====== Only Wired IRQs
-** One or more AIA APLIC devices to support wired interrupts
-** One or more ACLINT MSWI devices to support M-mode software interrupts
-** One or more ACLINT SSWI devices to support S/HS-mode software interrupts
-** Software interrupts for VS-mode supported using the SBI IPI extension
-** MSI external interrupts not supported
+** One or more AIA APLIC devices are required to support wired interrupts
+** One or more ACLINT MSWI devices are required to support M-mode software interrupts
+** One or more ACLINT SSWI devices are required to support S/HS-mode software interrupts
+** Software interrupts for VS-mode are supported using the SBI IPI extension
+** MSI external interrupts are not supported
 ** MSI virtualization is not supported
 
 [#msis_and_wired_irqs]
@@ -393,9 +388,9 @@ categories described in following sub-sections.
 ** One, or more AIA APLIC devices to support wired interrupts
 *** EIID and IID fields must be 6 to 8 bits wide matching the number of
     interrrupt identities supported by AIA IMSIC
-** Software interrupts for M-mode and S/HS-mode supported using AIA IMSIC
+** Software interrupts for M-mode and S/HS-mode are supported using AIA IMSIC
    devices
-** Software interrupts for VS-mode supported using the SBI IPI extension
+** Software interrupts for VS-mode are supported using the SBI IPI extension
 ** MSI virtualization is not supported
 
 [#msis_virtual_msis_and_wired_irqs]
@@ -410,10 +405,10 @@ categories described in following sub-sections.
 *** Must support at least 63 distinct interrupt identities
 *** Must implement `seteipnum_le` memory-mapped register
 *** Must implement at least 3 guest interrupt files
-** One, or more AIA APLIC devices to support wired interrupts
+** One, or more AIA APLIC devices are required to support wired interrupts
 *** EIID and IID fields must be 6 to 8 bits wide matching the number of
     interrrupt identities supported by AIA IMSIC
-** Software interrupts for M-mode, HS-mode and VS-mode supported using
+** Software interrupts for M-mode, HS-mode and VS-mode are supported using
    AIA IMSIC devices
 ** MSI virtualization is supported
 
@@ -448,68 +443,68 @@ categories of interrupt support and timer support allowed in a OS-A platorm.
 |+++<font size=".6em">NA</font>+++
 |+++<font size=".6em">NA</font>+++
 |+++<font size=".6em">NA</font>+++
-|+++<font size=".6em">PLIC</font>+++ ^<<spec_plic>>^
-|+++<font size=".6em">PLIC</font>+++ ^<<spec_plic>>^
-|+++<font size=".6em">PLIC (emulate)</font>+++ ^<<spec_plic>>^
-|+++<color rgb="#6aa84f"><font size=".6em">MSWI</font></color>+++ ^<<spec_aclint>>^
-|+++<color rgb="#e06666"><font size=".6em">SBI IPI</font></color>+++ ^<<spec_sbi>>^
-|+++<color rgb="#e06666"><font size=".6em">SBI IPI</font></color>+++ ^<<spec_sbi>>^
-|+++<color rgb="#6aa84f"><font size=".6em">MTIMER</font></color>+++ ^<<spec_aclint>>^
-|+++<color rgb="#e06666"><font size=".6em">SBI Timer</font></color>+++ ^<<spec_sbi>>^
-|+++<color rgb="#e06666"><font size=".6em">SBI Timer</font></color>+++ ^<<spec_sbi>>^
+|+++<font size=".6em">PLIC</font>+++
+|+++<font size=".6em">PLIC</font>+++
+|+++<font size=".6em">PLIC (emulate)</font>+++
+|+++<color rgb="#6aa84f"><font size=".6em">MSWI</font></color>+++
+|+++<color rgb="#e06666"><font size=".6em">SBI IPI</font></color>+++
+|+++<color rgb="#e06666"><font size=".6em">SBI IPI</font></color>+++
+|+++<color rgb="#6aa84f"><font size=".6em">MTIMER</font></color>+++
+|+++<color rgb="#e06666"><font size=".6em">SBI Timer</font></color>+++
+|+++<color rgb="#e06666"><font size=".6em">SBI Timer</font></color>+++
 
 |+++<font size=".8em">Only Wired IRQs</font>+++
 |+++<font size=".6em">NA</font>+++
 |+++<font size=".6em">NA</font>+++
 |+++<font size=".6em">NA</font>+++
-|+++<color rgb="#738dc5"><font size=".6em">APLIC</font></color>+++ ^<<spec_aia>>^
-|+++<color rgb="#738dc5"><font size=".6em">APLIC</font></color>+++ ^<<spec_aia>>^
-|+++<color rgb="#738dc5"><font size=".6em">APLIC (emulate)</font></color>+++ ^<<spec_aia>>^
-|+++<color rgb="#6aa84f"><font size=".6em">MSWI</font></color>+++ ^<<spec_aclint>>^
-|+++<color rgb="#6aa84f"><font size=".6em">SSWI</font></color>+++ ^<<spec_aclint>>^
-|+++<color rgb="#e06666"><font size=".6em">SBI IPI</font></color>+++ ^<<spec_sbi>>^
-|+++<color rgb="#6aa84f"><font size=".6em">MTIMER</font></color>+++ ^<<spec_aclint>>^
-|+++<color rgb="#e69138"><font size=".6em">Priv Sstc</font></color>+++ ^<<spec_priv_sstc>>^
-|+++<color rgb="#e69138"><font size=".6em">Priv Sstc</font></color>+++ ^<<spec_priv_sstc>>^
+|+++<color rgb="#738dc5"><font size=".6em">APLIC</font></color>+++
+|+++<color rgb="#738dc5"><font size=".6em">APLIC</font></color>+++
+|+++<color rgb="#738dc5"><font size=".6em">APLIC (emulate)</font></color>+++
+|+++<color rgb="#6aa84f"><font size=".6em">MSWI</font></color>+++
+|+++<color rgb="#6aa84f"><font size=".6em">SSWI</font></color>+++
+|+++<color rgb="#e06666"><font size=".6em">SBI IPI</font></color>+++
+|+++<color rgb="#6aa84f"><font size=".6em">MTIMER</font></color>+++
+|+++<color rgb="#e69138"><font size=".6em">Priv Sstc</font></color>+++
+|+++<color rgb="#e69138"><font size=".6em">Priv Sstc</font></color>+++
 
 |+++<font size=".8em">MSIs and Wired IRQs</font>+++
-|+++<color rgb="#738dc5"><font size=".6em">IMSIC</font></color>+++ ^<<spec_aia>>^
-|+++<color rgb="#738dc5"><font size=".6em">IMSIC</font></color>+++ ^<<spec_aia>>^
-|+++<color rgb="#738dc5"><font size=".6em">IMSIC (emulate)</font></color>+++ ^<<spec_aia>>^
-|+++<color rgb="#738dc5"><font size=".6em">APLIC</font></color>+++ ^<<spec_aia>>^
-|+++<color rgb="#738dc5"><font size=".6em">APLIC</font></color>+++ ^<<spec_aia>>^
-|+++<color rgb="#738dc5"><font size=".6em">APLIC (emulate)</font></color>+++ ^<<spec_aia>>^
-|+++<color rgb="#738dc5"><font size=".6em">IMSIC</font></color>+++ ^<<spec_aia>>^
-|+++<color rgb="#738dc5"><font size=".6em">IMSIC</font></color>+++ ^<<spec_aia>>^
-|+++<color rgb="#e06666"><font size=".6em">SBI IPI</font></color>+++ ^<<spec_sbi>>^
-|+++<color rgb="#6aa84f"><font size=".6em">MTIMER</font></color>+++ ^<<spec_aclint>>^
-|+++<color rgb="#e69138"><font size=".6em">Priv Sstc</font></color>+++ ^<<spec_priv_sstc>>^
-|+++<color rgb="#e69138"><font size=".6em">Priv Sstc</font></color>+++ ^<<spec_priv_sstc>>^
+|+++<color rgb="#738dc5"><font size=".6em">IMSIC</font></color>+++
+|+++<color rgb="#738dc5"><font size=".6em">IMSIC</font></color>+++
+|+++<color rgb="#738dc5"><font size=".6em">IMSIC (emulate)</font></color>+++
+|+++<color rgb="#738dc5"><font size=".6em">APLIC</font></color>+++
+|+++<color rgb="#738dc5"><font size=".6em">APLIC</font></color>+++
+|+++<color rgb="#738dc5"><font size=".6em">APLIC (emulate)</font></color>+++
+|+++<color rgb="#738dc5"><font size=".6em">IMSIC</font></color>+++
+|+++<color rgb="#738dc5"><font size=".6em">IMSIC</font></color>+++
+|+++<color rgb="#e06666"><font size=".6em">SBI IPI</font></color>+++
+|+++<color rgb="#6aa84f"><font size=".6em">MTIMER</font></color>+++
+|+++<color rgb="#e69138"><font size=".6em">Priv Sstc</font></color>+++
+|+++<color rgb="#e69138"><font size=".6em">Priv Sstc</font></color>+++
 
 |+++<font size=".8em">MSIs, Virtual MSIs and Wired IRQs</font>+++
-|+++<color rgb="#738dc5"><font size=".6em">IMSIC</font></color>+++ ^<<spec_aia>>^
-|+++<color rgb="#738dc5"><font size=".6em">IMSIC</font></color>+++ ^<<spec_aia>>^
-|+++<color rgb="#738dc5"><font size=".6em">IMSIC</font></color>+++ ^<<spec_aia>>^
-|+++<color rgb="#738dc5"><font size=".6em">APLIC</font></color>+++ ^<<spec_aia>>^
-|+++<color rgb="#738dc5"><font size=".6em">APLIC</font></color>+++ ^<<spec_aia>>^
-|+++<color rgb="#738dc5"><font size=".6em">APLIC (emulate)</font></color>+++ ^<<spec_aia>>^
-|+++<color rgb="#738dc5"><font size=".6em">IMSIC</font></color>+++ ^<<spec_aia>>^
-|+++<color rgb="#738dc5"><font size=".6em">IMSIC</font></color>+++ ^<<spec_aia>>^
-|+++<color rgb="#738dc5"><font size=".6em">IMSIC</font></color>+++ ^<<spec_aia>>^
-|+++<color rgb="#6aa84f"><font size=".6em">MTIMER</font></color>+++ ^<<spec_aclint>>^
-|+++<color rgb="#e69138"><font size=".6em">Priv Sstc</font></color>+++ ^<<spec_priv_sstc>>^
-|+++<color rgb="#e69138"><font size=".6em">Priv Sstc</font></color>+++ ^<<spec_priv_sstc>>^
+|+++<color rgb="#738dc5"><font size=".6em">IMSIC</font></color>+++
+|+++<color rgb="#738dc5"><font size=".6em">IMSIC</font></color>+++
+|+++<color rgb="#738dc5"><font size=".6em">IMSIC</font></color>+++
+|+++<color rgb="#738dc5"><font size=".6em">APLIC</font></color>+++
+|+++<color rgb="#738dc5"><font size=".6em">APLIC</font></color>+++
+|+++<color rgb="#738dc5"><font size=".6em">APLIC (emulate)</font></color>+++
+|+++<color rgb="#738dc5"><font size=".6em">IMSIC</font></color>+++
+|+++<color rgb="#738dc5"><font size=".6em">IMSIC</font></color>+++
+|+++<color rgb="#738dc5"><font size=".6em">IMSIC</font></color>+++
+|+++<color rgb="#6aa84f"><font size=".6em">MTIMER</font></color>+++
+|+++<color rgb="#e69138"><font size=".6em">Priv Sstc</font></color>+++
+|+++<color rgb="#e69138"><font size=".6em">Priv Sstc</font></color>+++
 |===
 
 ==== System Peripherals
-* UART/Serial Console
+===== UART/Serial Console
 
-In order to facilitate the bringup and debug of the low level initial platform
+In order to facilitate the bring-up and debug of the low level initial platform
 software(firmware, bootloaders, kernel etc), platforms are required to
 implement a UART port which confirms to the following requirements:
 
 * The UART register addresses are required to be aligned to 4 byte boundaries.
-If the implemented register width is less than 4 bytes then the implmented
+If the implemented register width is less than 4 bytes then the implemented
 bytes are required to be mapped starting at the smallest address.
 * The UART port implementation is required to be register-compatible with one
 of the following:
@@ -517,15 +512,15 @@ of the following:
 ** UART 8250 - _DEPRECATED_
 
 ==== Boot Process
-- The base specification defines the interface between the firmware and the 
-operating system suitable for the RISC-V platforms with rich operating 
+- The base specification defines the interface between the firmware and the
+operating system suitable for the RISC-V platforms with rich operating
 systems.
-- These requirements specify the required boot and runtime services, device 
-discovery mechanism, etc. 
+- These requirements specify the required boot and runtime services, device
+discovery mechanism, etc.
 - The requirements are operating system agnostic, specific firmware/bootloader
 implementation agnostic.
 - For the generic mandatory requirements this base specification will refer to
-the EBBR Specification. Any deviation from the EBBR will be explicitly 
+the EBBR Specification. Any deviation from the EBBR will be explicitly
 mentioned in the requirements.
 
 
@@ -534,9 +529,9 @@ mentioned in the requirements.
 - GPT partitioning required for shared storage.
 - MBR support is not required
 
-===== Discovery Mechanisms 
+===== Hardware Discovery Mechanisms
 - Device Tree (DT) is the required mechanism for system description.
-- Platforms must support the Unified Discovery specification for all pre-boot 
+- Platforms must support the Unified Discovery specification for all pre-boot
 information population <<spec_unified_discovery>>
 
 
@@ -662,7 +657,7 @@ following additional requirements:
 * EIID and IID fields of AIA APLIC devices must be at least 8 bits wide
   matching the number of interrrupt identities supported by AIA IMSIC
 
-==== Boot and Runtime Requirements
+==== Boot Process
 =====  Firmware
 The boot and system firmware for the server platforms must support UEFI as
 defined in by the OS-A base platform with some additional requirements
@@ -724,9 +719,9 @@ characteristics and HART hardware features discovered during the firmware boot
 process.
 |===
 
-===== Runtime services
+==== Runtime services
 
-====== UEFI
+===== UEFI
 The UEFI run time services listed below are required to be implemented.
 
 .Required UEFI Runtime Services
@@ -803,14 +798,14 @@ Platforms are required to support at least PCIe Base Specification Revision 1.1
 <<spec_pcie_sig>>.
 
 ====== PCIe Config Space
-* Platforms shall support access to the PCIe config space via ECAM as described
+* Platforms must support access to the PCIe config space via ECAM as described
 in the PCIe Base specification.
-* The entire config space for a single PCIe domain should be accessible via a
+* The entire config space for a single PCIe domain must be accessible via a
 single ECAM I/O region.
-* Platform firmware should implement the MCFG table as listed in the ACPI System
+* Platform firmware must implement the MCFG table as listed in the ACPI System
 Description Tables above to allow the operating systems to discover the supported
 PCIe domains and map the ECAM I/O region for each domain.
-* Platform software shall configure ECAM I/O regions such that the effective
+* Platform software must configure ECAM I/O regions such that the effective
 memory attributes are that of a PMA I/O region (i.e. strongly-ordered,
 non-cacheable, non-idempotent).
 
@@ -849,13 +844,13 @@ as described in the RISC-V Privileged Architectures specification.
 --
 
 ====== PCIe Interrupts
-* Platforms shall support both INTx and MSI/MSI-x interrupts.
+* Platforms must support both INTx and MSI/MSI-x interrupts.
 * Following are the requirements for INTx:
-** For each root port in the system, the platform shall map all the INTx
+** For each root port in the system, the platform must map all the INTx
 virtual wires to four distinct sources at the APLIC. Each of these sources
-shall be configured as Level0 as described in Table 4.2 (Encoding of the SM
+must be configured as Level0 as described in Table 4.2 (Encoding of the SM
 (Source Mode) field) of the RISC V AIA specification.
-** Platform firmware shall implement the _PRT as described in section 6.2.13 of
+** Platform firmware must implement the _PRT as described in section 6.2.13 of
 ACPI Specification to describe the mapping of interrupt pins and the
 corresponding interrupt minor identities at the Hart.
 ** If interrupt generation for correctable/fatal/non-fatal error messages is
@@ -873,7 +868,7 @@ of the 16 vectors.
 ====== PCIe cache coherency
 Memory that is cacheable by harts is not kept coherent by hardware when PCIe
 transactions to that memory are marked with a No_Snoop bit of zero. In this
-case, software shall manage coherency on such memory; otherwise, software
+case, software must manage coherency on such memory; otherwise, software
 coherency management is not required.
 
 ====== PCIe Topology
@@ -887,53 +882,53 @@ image::pcie-topology.png[width=524,height=218]
 * Host Bridge +
 Following are the requirements for host bridges:
 
-** Any read or write access by a hart to an ECAM I/O region shall be converted
+** Any read or write access by a hart to an ECAM I/O region must be converted
 by the host bridge into the corresponding PCIe config read or config write
 request.
-** Any read or write access by a hart to a PCIe outbound region shall be
+** Any read or write access by a hart to a PCIe outbound region must be
 forwarded by the host bridge to a BAR or prefetch/non-prefetch memory window,
 if the address falls within the region claimed by the BAR or prefetch/
-non-prefetch memory window. Otherwise the host bridge shall return an error.
+non-prefetch memory window. Otherwise the host bridge must return an error.
 
-** Host bridge shall return all 1s in the following cases:
+** Host bridge must return all 1s in the following cases:
 *** Config read to non existent functions and devices on root bus.
 *** Config reads that receive Unsupported Request response from functions and
 devices on the root bus.
 * Root ports +
 Following are the requirements for root ports.
-** Root ports shall appear as PCI-PCI bridge to software.
-** Root ports shall implement all registers of Type 1 header.
-** Root ports shall implement all capabilities specified in the PCIe Base
+** Root ports must appear as PCI-PCI bridge to software.
+** Root ports must implement all registers of Type 1 header.
+** Root ports must implement all capabilities specified in the PCIe Base
 specification for a root port.
-** Root ports shall forward type 1 configuration access when the bus number in
+** Root ports must forward type 1 configuration access when the bus number in
 the TLP is greater than the root port's secondary bus number and less than or
 equal to the root port's subordinate bus number.
-** Root ports shall convert type 1 configuration access to a type 0
+** Root ports must convert type 1 configuration access to a type 0
 configuration access when bus number in the TLP is equal to the root port's
 secondary bus number.
-** Root ports shall respond to any type 0 configuration accesses it receives.
-** Root ports shall forward memory accesses targeting its prefetch/non-prefetch
+** Root ports must respond to any type 0 configuration accesses it receives.
+** Root ports must forward memory accesses targeting its prefetch/non-prefetch
 memory windows to downstream components. If address of the transaction does not
 fall within the regions claimed by prefetch/non-prefetch memory windows then
-the root port shall generate a Unsupported Request.
-** Root port requester id or completer id shall be formed using the bdf of the
+the root port must generate a Unsupported Request.
+** Root port requester id or completer id must be formed using the bdf of the
 root port.
-** The root ports shall support the CRS software visibility.
-** The root port shall implement the AER capability.
-** Root ports shall return all 1s in the following cases:
+** The root ports must support the CRS software visibility.
+** The root port must implement the AER capability.
+** Root ports must return all 1s in the following cases:
 *** Config read to non existent functions and devices on secondary bus.
 *** Config reads that receive Unsupported Request from downstream components.
 *** Config read when root port's link is down.
 
 * RCiEP +
-All the requirements for RCiEP in the PCIe Base specification shall be
+All the requirements for RCiEP in the PCIe Base specification must be
 implemented.
-In addition the following requirements shall be met:
-** If RCiEP is implemented then RCEC shall be implemented as well. All
-requirements for RCEC specified in the PCIe Base specification shall be
+In addition the following requirements must be met:
+** If RCiEP is implemented then RCEC must be implemented as well. All
+requirements for RCEC specified in the PCIe Base specification must be
 implemented. RCEC is required to terminate the AER and PME messages from RCiEP.
 ** If both the topologies mentioned above are supported then RCiEP and RCEC
-shall be implemented in a separate PCIe domain and shall be addressable via a
+must be implemented in a separate PCIe domain and must be addressable via a
 separate ECAM I/O region.
 
 ===== PCIe Device Firmware Requirement
@@ -944,27 +939,27 @@ stored in PCI expansion ROM is an UEFI driver that must be compliant with
 UEFI specification <<spec_uefi>> 14.4.2 PCI Option ROMs.
 
 
-==== Security 
+==== Security
 Platforms must implement the following security features:
 
-* Support for some form of Secure Boot, as a means to ensure the integrity of 
-platform firmware and software, is required. Flexibility is provided as 
-to the many details and implementation approaches. Future platform specs are 
-expected to standardize some or many of these aspects. For now, it is 
+* Support for some form of Secure Boot, as a means to ensure the integrity of
+platform firmware and software, is required. Flexibility is provided as
+to the many details and implementation approaches. Future platform specs are
+expected to standardize some or many of these aspects. For now, it is
 recommended that the following security properties are met:
 ** The secure boot process is rooted in dedicated hardware.
-** Cryptographic algorithms are independently validated or certified for 
+** Cryptographic algorithms are independently validated or certified for
 implementation correctness.
-** The combination of key length and cryptographic algorithm provides suitable 
+** The combination of key length and cryptographic algorithm provides suitable
 security strength.
-** A cryptographically secure entropy source (or multiple entropy sources) is 
-used in key material generation and monitoring of entropy source’s health is 
+** A cryptographically secure entropy source (or multiple entropy sources) is
+used in key material generation and monitoring of entropy source’s health is
 implemented.
-** Critical security parameters are securely stored and only accessible with 
+** Critical security parameters are securely stored and only accessible with
 appropriate privileges.
-** Authorization is required for any modifications to the platform secure boot 
+** Authorization is required for any modifications to the platform secure boot
 configuration.
-** It is clearly understood what aspects of the platform boot process are 
+** It is clearly understood what aspects of the platform boot process are
 protected by secure boot.
 
 
@@ -997,14 +992,14 @@ S/HS-mode for firmware-first or OS-first error reporting. +
 * If the RAS error is handled by firmware, the firmware should be able
 to choose to expose the error to S/HS mode for further processing or
 just hide the error from S/HS software. +
-* If the RAS event is configured as the firmware first model, the platform 
-should be able to trigger the higest priority of M-mode interrupt to all HARTs 
+* If the RAS event is configured as the firmware first model, the platform
+should be able to trigger the highest priority of M-mode interrupt to all HARTs
 in the physical RV processor. +
 * Logging and/or reporting of errors can be masked. +
 * PCIe AER capability is required. +
 
 // M Platform
-== M Platform 
+== M Platform
 
 === Scope
 The M Platform specification aims to apply to a range of embedded platforms.
@@ -1080,7 +1075,7 @@ implementations should aim for supporting at least 16 PMP regions.
 * [[[spec_proc_call,12]]] link:https://github.com/riscv/riscv-elf-psabi-doc[RISC-V Procedure call standard], Version: draft-20210810
 * [[[spec_elf,13]]] link:https://github.com/riscv/riscv-elf-psabi-doc[RISC-V ELF specification], Version: draft-20210810
 * [[[spec_dwarf,14]]] link:https://github.com/riscv/riscv-elf-psabi-doc[RISC-V DWARF specification], Version: draft-20210810
-* [[[spec_ebbr,15]]] link:https://arm-software.github.io/ebbr/[EBBR Specification], Version: v2.0.1    
+* [[[spec_ebbr,15]]] link:https://arm-software.github.io/ebbr/[EBBR Specification], Version: v2.0.1
 * [[[spec_acpi,16]]] link:https://uefi.org/sites/default/files/resources/ACPI_Spec_6_4_Jan22.pdf[ACPI Specification], Version: v6.4
 * [[[spec_apei,17]]] link:https://uefi.org/specs/ACPI/6.4/18_ACPI_Platform_Error_Interfaces/ACPI_PLatform_Error_Interfaces.html[APEI Specification], Version: v6.4
 * [[[spec_smbios,18]]] link:https://www.dmtf.org/sites/default/files/standards/documents/DSP0134_3.4.0.pdf[SMBIOS Specification], Version: v3.4.0


### PR DESCRIPTION
This patch includes the following changes which are mostly semantic.

1. Uniform usage of must instead of shall
2. Typo fixes
3. Remove references from interrupt table
4. Remove stray white spaces
5. Align boot process section/subsection names between base & server extension

Signed-off-by: Atish Patra <atish.patra@wdc.com>