### PR TITLE
Typo cleanups

### DIFF
--- a/riscv-platform-spec.adoc
+++ b/riscv-platform-spec.adoc
@@ -860,7 +860,7 @@ enabled via the root error command register of the AER capability and the root
 port does not support MSI/MSI-X capability, then the platform is required to
 generate an INTx interrupt via the APLIC.
 * Following are the requirements for MSI:
-** As per the RISC-V AIA specification since the number 0 is not a valid
+** As per the RISC-V AIA specification, since the number 0 is not a valid
 interrupt identity, the platform software is required to ensure that MSI data
 value assigned to a PCIe function is never 0. For e.g for a PCIe function which
 requests 16 MSI vectors the minimum MSI data value assigned by the platform

--- a/riscv-platform-spec.adoc
+++ b/riscv-platform-spec.adoc
@@ -851,7 +851,7 @@ as described in the RISC-V Privileged Architectures specification.
 ** For each root port in the system, the platform must map all the INTx
 virtual wires to four distinct sources at the APLIC. Each of these sources
 must be configured as Level0 as described in Table 4.2 (Encoding of the SM
-(Source Mode) field) of the RISC V AIA specification.
+(Source Mode) field) of the RISC-V AIA specification.
 ** Platform firmware must implement the _PRT as described in section 6.2.13 of
 ACPI Specification to describe the mapping of interrupt pins and the
 corresponding interrupt minor identities at the Hart.
@@ -860,7 +860,7 @@ enabled via the root error command register of the AER capability and the root
 port does not support MSI/MSI-X capability, then the platform is required to
 generate an INTx interrupt via the APLIC.
 * Following are the requirements for MSI:
-** As per the RISC V AIA specification since the number 0 is not a valid
+** As per the RISC-V AIA specification since the number 0 is not a valid
 interrupt identity, the platform software is required to ensure that MSI data
 value assigned to a PCIe function is never 0. For e.g for a PCIe function which
 requests 16 MSI vectors the minimum MSI data value assigned by the platform

--- a/riscv-platform-spec.adoc
+++ b/riscv-platform-spec.adoc
@@ -663,7 +663,7 @@ following additional requirements:
 =====  Firmware
 The boot and system firmware for the server platforms must support UEFI as
 defined in by the OS-A base platform with some additional requirements
-described in following sub-setions.
+described in following sub-sections.
 
 ====== PCIe support
 The platforms are required to implement *EFI_PCI_ROOT_BRIDGE_IO_PROTOCOL* and 

--- a/riscv-platform-spec.adoc
+++ b/riscv-platform-spec.adoc
@@ -626,7 +626,7 @@ caches.
 --
 [underline]*_Implementation Note_*
 
-Any platform that do not implement the micro-architectural features related to
+Any platform that does not implement the micro-architectural features related to
 a hardware event may hardwire the event value to zero.
 --
 


### PR DESCRIPTION
Fix one typo, one grammar nit as well as two misspellings of RISC-V in the Server section.
While at it, also clarify one sentence being touched.