### PR TITLE
Correct scope of specification.

### DIFF
--- a/riscv-platform-spec.adoc
+++ b/riscv-platform-spec.adoc
@@ -110,9 +110,8 @@ feature set and extensions as shown below: +
 ** *Physical Memory Protection (PMP) Extension*
 
 The current version of this platform spec targets the standardization of
-functionality available in S, U, VS and VU modes, and the standardization of
-the SBI (Supervisory Binary Interface as defined in <<spec_sbi>>) between
-Supervisor level (S-mode/VS-mode) and M-mode/HS-mode respectively.
+functionality available in S and VS modes, and the standardization of
+the SBI (Supervisory Binary Interface as defined in <<spec_sbi>>).
 
 // OS-A Platform Common requirements
 == OS-A Common Requirements 


### PR DESCRIPTION
Remove statements that do not apply to the current scope.  That is, remove
statements about standardization of U/VU modes, and remove the statement
that the SBI is a standard between S/VS and M/HS modes.

This issue was raised twice on the mailing list when these changes were
proposed but there was never any response.

https://lists.riscv.org/g/tech-unixplatformspec/message/1479
https://lists.riscv.org/g/tech-unixplatformspec/message/1536
